### PR TITLE
fix IOS multiple credit card

### DIFF
--- a/ios/AdyenPayment.swift
+++ b/ios/AdyenPayment.swift
@@ -174,7 +174,6 @@ class AdyenPayment: RCTEventEmitter {
                 print(stored_py_mthd.type)
                 if(stored_py_mthd.type == "scheme"){
                     storedPaymentMethods.append(stored_py_mthd)
-                    break
                 }
             }
             let dropInComponent = DropInComponent(paymentMethods: PaymentMethods(regular:regularPaymentMethods, stored:storedPaymentMethods),paymentMethodsConfiguration: configuration)


### PR DESCRIPTION
AS a customer with multiple stored Credit Cards, i can view and select an old one 
This PR fix the following issue :  #15